### PR TITLE
chore: add dependencies and CLI entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,68 @@ Now, AI agents generate visualizations at scale, but they do so blindly. LLMs ca
 
 Users get reliable visualizations by default, without even thinking about it. The way it always should have been.
 
+## Quick Start
+
+### Installation
+
+```bash
+# Install from source (PyPI release coming soon)
+git clone https://github.com/yourusername/chartelier.git
+cd chartelier
+uv sync
+```
+
+### Usage
+
+#### As an MCP Server
+
+Chartelier provides an MCP (Model Context Protocol) server that can be used with Claude Desktop, VSCode, or other MCP-compatible clients:
+
+```bash
+# Start the MCP server (stdio mode)
+chartelier-mcp
+
+# Show available options
+chartelier-mcp --help
+```
+
+#### MCP Configuration Example
+
+To use with Claude Desktop, add to your MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "chartelier": {
+      "command": "chartelier-mcp",
+      "args": [],
+      "env": {}
+    }
+  }
+}
+```
+
+The server exposes the `chartelier_visualize` tool that accepts:
+- `data`: CSV or JSON data as a string
+- `query`: Natural language description of the desired visualization
+- `options`: Optional formatting parameters (format, dpi, width, height, locale)
+
+Example usage from an AI agent:
+```json
+{
+  "tool": "chartelier_visualize",
+  "parameters": {
+    "data": "date,sales\\n2024-01,100\\n2024-02,150\\n2024-03,120",
+    "query": "Show monthly sales trend",
+    "options": {
+      "format": "png",
+      "width": 800,
+      "height": 600
+    }
+  }
+}
+```
+
 ## Development Setup
 
 ### Prerequisites

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,11 @@ dependencies = [
     "polars>=1.0.0",
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
+    "vl-convert-python>=1.0.0",
 ]
+
+[project.scripts]
+chartelier-mcp = "chartelier.interfaces.mcp.server:main"
 
 [project.optional-dependencies]
 dev = [

--- a/src/chartelier/interfaces/mcp/server.py
+++ b/src/chartelier/interfaces/mcp/server.py
@@ -1,0 +1,88 @@
+"""MCP server entry point for Chartelier."""
+
+import argparse
+import json
+import logging
+import sys
+
+# Configure logging
+logging.basicConfig(
+    level=logging.WARNING,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    stream=sys.stderr,
+)
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    """Main entry point for the Chartelier MCP server.
+
+    This is a minimal implementation that will be expanded in future PRs.
+    Currently, it only provides basic CLI functionality for testing.
+    """
+    parser = argparse.ArgumentParser(
+        prog="chartelier-mcp",
+        description="Chartelier MCP Server - MCP-compliant visualization tool for AI agents",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Start the MCP server (stdio mode)
+  chartelier-mcp
+
+  # Show version information
+  chartelier-mcp --version
+
+  # Show this help message
+  chartelier-mcp --help
+
+Note: This is a minimal implementation. Full MCP functionality will be added in subsequent PRs.
+        """.strip(),
+    )
+
+    parser.add_argument(
+        "--version", action="version", version="chartelier-mcp 0.1.0", help="show version information and exit"
+    )
+
+    parser.add_argument(
+        "--mode", choices=["stdio"], default="stdio", help="communication mode (currently only stdio is supported)"
+    )
+
+    parser.add_argument("--debug", action="store_true", help="enable debug logging")
+
+    args = parser.parse_args()
+
+    # Set logging level based on debug flag
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    if args.mode == "stdio":
+        # Minimal stdio mode implementation
+        # Full MCP server implementation will be added in PR-C1
+        logger.debug("Starting Chartelier MCP server in stdio mode")
+
+        # For now, just echo a minimal response to show the server is working
+        # This will be replaced with proper MCP protocol handling in PR-C1
+        try:
+            # Read a single line for testing purposes
+            # In the full implementation, this will be a proper JSON-RPC loop
+            line = sys.stdin.readline()
+            if line:
+                # Echo back a minimal response
+                response = {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {"message": "Chartelier MCP server is running (minimal mode)", "version": "0.1.0"},
+                }
+                sys.stdout.write(json.dumps(response) + "\n")
+                sys.stdout.flush()
+        except KeyboardInterrupt:
+            logger.debug("Server interrupted")
+            sys.exit(0)
+        except Exception:
+            logger.exception("Error in server")
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -238,6 +238,7 @@ dependencies = [
     { name = "polars" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "vl-convert-python" },
 ]
 
 [package.optional-dependencies]
@@ -276,6 +277,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.4" },
     { name = "tox", marker = "extra == 'dev'", specifier = ">=4.23.2" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.32.0.20241016" },
+    { name = "vl-convert-python", specifier = ">=1.0.0" },
 ]
 provides-extras = ["dev", "mcp", "litellm"]
 
@@ -1823,6 +1825,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/14/37fcdba2808a6c615681cd216fecae00413c9dab44fb2e57805ecf3eaee3/virtualenv-20.34.0.tar.gz", hash = "sha256:44815b2c9dee7ed86e387b842a84f20b93f7f417f95886ca1996a72a4138eb1a", size = 6003808, upload-time = "2025-08-13T14:24:07.464Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/06/04c8e804f813cf972e3262f3f8584c232de64f0cde9f703b46cf53a45090/virtualenv-20.34.0-py3-none-any.whl", hash = "sha256:341f5afa7eee943e4984a9207c025feedd768baff6753cd660c857ceb3e36026", size = 5983279, upload-time = "2025-08-13T14:24:05.111Z" },
+]
+
+[[package]]
+name = "vl-convert-python"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/08/06945bff9655c5b0520a8d1b2550cd8007e106ebec45a33840035420e0d2/vl_convert_python-1.8.0.tar.gz", hash = "sha256:ceca613ca5551c55270a15ca48d0f3a7de1e949e0f127310e9b0f6570ea3fbbb", size = 4651586, upload-time = "2025-05-28T00:06:47.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5a/9dca7d8ff56e82c298e9ef381cfc803e262b85b7c59f2515d0e9f81a75b6/vl_convert_python-1.8.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f663317fc280b07553534195c1e31c4ca882d9c8601430211b078196db5ed227", size = 29956698, upload-time = "2025-05-28T00:06:29.533Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e2/325e6b5895482b2534e7462c012f237c66ffb02fb3af45eec0accab2f8d4/vl_convert_python-1.8.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:81f6380019ceadf070a79f85aa624475a6568093f70de0e151a32e91ecbcaacf", size = 28831173, upload-time = "2025-05-28T00:06:32.925Z" },
+    { url = "https://files.pythonhosted.org/packages/09/fa/1dd944c9e9898e59e31c385bdce215aca543acc555de20b8bf4dc60ddb89/vl_convert_python-1.8.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3388e3913287867b3553c10f81ca2d85268216a5a75e7c71b9c1b59887c1977e", size = 31668750, upload-time = "2025-05-28T00:06:36.158Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6b/48f6d47a92eaf6f0dd235146307a7eb0d179b78d2faebc53aca3f1e49177/vl_convert_python-1.8.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b51264998e8fcc43dbce801484a950cfe6513cdc4c46b20604ef50989855a617", size = 32970141, upload-time = "2025-05-28T00:06:41.323Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/6f/29dce05f9167e3a01ab74d79eeadd531bc24cf59e3a7fc3736af476ca431/vl_convert_python-1.8.0-cp37-abi3-win_amd64.whl", hash = "sha256:9f1146b791ed27916f54c45e1d66af53a40eb26e5aaea1892f33eb9a935039ab", size = 31318167, upload-time = "2025-05-28T00:06:44.881Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Add vl-convert-python dependency and minimal MCP server entry point as part of PR-A2 from the MVP delivery plan.

## Purpose
This PR establishes the foundational package dependencies and CLI entry point required for the Chartelier MCP server implementation.

## Changes
- **Dependencies**: Added `vl-convert-python>=1.0.0` to project dependencies for PNG/SVG export capabilities
- **CLI Entry Point**: Defined `chartelier-mcp` script in `[project.scripts]` section of pyproject.toml
- **MCP Server Stub**: Created minimal MCP server implementation at `src/chartelier/interfaces/mcp/server.py` with:
  - Basic argparse CLI with `--help`, `--version`, and `--debug` options
  - Placeholder stdio mode that will be expanded in PR-C1
  - Proper logging configuration using Python's logging module
- **Documentation**: Updated README.md with Quick Start section including:
  - Installation instructions
  - MCP server usage examples
  - MCP configuration for Claude Desktop
  - Example tool invocation format

## Test Plan
✅ CLI launches successfully with `uv run chartelier-mcp --help`
✅ Version information displays correctly with `--version`
✅ All pre-commit hooks pass (ruff, mypy, pytest)
✅ Dependencies install correctly with `uv sync`

## Dependencies
This PR follows PR-A1 (ADR-0002 alignment) and is part of Block A (Project Foundation & Alignment).

## Next Steps
- PR-C1 will implement the full MCP protocol handling
- PR-C2 will add request validation
- PR-C3 will integrate with the Coordinator for actual visualization processing

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>