### PR TITLE
feat: add vertical spacing between chart title and content

### DIFF
--- a/src/chartelier/core/chart_builder/themes.py
+++ b/src/chartelier/core/chart_builder/themes.py
@@ -80,6 +80,7 @@ class Theme:
                 fontSize=22,  # Increased for 300dpi readability
                 fontWeight=600,  # Semi-bold instead of bold for better balance
                 anchor="start",
+                offset=12,  # Add spacing between title and chart area
             )
             .configure_view(
                 strokeWidth=0,  # No border around chart area
@@ -133,6 +134,7 @@ class Theme:
                 "fontSize": 22,  # Increased for 300dpi readability
                 "fontWeight": 600,  # Semi-bold instead of bold for better balance
                 "anchor": "start",
+                "offset": 12,  # Add spacing between title and chart area
             },
             "view": {
                 "strokeWidth": 0,


### PR DESCRIPTION
## Summary
- Add 12px offset between chart title and content area for improved visual hierarchy
- Apply spacing consistently across all chart templates via theme configuration

## Changes
- Modified `themes.py` to add `offset: 12` parameter to title configuration
- Updated both `configure_title()` method and `get_base_config()` dictionary

## Test Plan
- [x] Visual tests pass (`uv run pytest tests/local/visual_output/`)
- [x] All existing tests continue to pass
- [x] Generated charts show proper spacing between title and content

## Visual Impact
The title now has clear separation from the chart content, improving readability and visual hierarchy without requiring changes to individual chart templates.

🤖 Generated with [Claude Code](https://claude.ai/code)