### PR TITLE
fix: remove target_line from histogram templates

### DIFF
--- a/src/chartelier/core/chart_builder/templates/p03/histogram.py
+++ b/src/chartelier/core/chart_builder/templates/p03/histogram.py
@@ -7,7 +7,7 @@ import altair as alt
 import polars as pl
 
 from chartelier.core.chart_builder.base import BaseTemplate, TemplateSpec
-from chartelier.core.enums import AuxiliaryElement, PatternID
+from chartelier.core.enums import PatternID
 from chartelier.core.models import MappingConfig
 
 
@@ -26,9 +26,7 @@ class HistogramTemplate(BaseTemplate):
             pattern_ids=["P03"],  # Overview only - Distribution/composition
             required_encodings=["x"],
             optional_encodings=["color", "opacity"],
-            allowed_auxiliary=[
-                AuxiliaryElement.TARGET_LINE,
-            ],
+            allowed_auxiliary=[],  # Target line not applicable for histograms (y-axis is frequency)
         )
 
     def build(

--- a/src/chartelier/core/chart_builder/templates/p13/facet_histogram.py
+++ b/src/chartelier/core/chart_builder/templates/p13/facet_histogram.py
@@ -7,7 +7,6 @@ import altair as alt
 import polars as pl
 
 from chartelier.core.chart_builder.base import BaseTemplate, TemplateSpec
-from chartelier.core.enums import AuxiliaryElement
 from chartelier.core.models import MappingConfig
 
 
@@ -26,9 +25,7 @@ class FacetHistogramTemplate(BaseTemplate):
             pattern_ids=["P13"],  # Transition + Overview - Distribution over time
             required_encodings=["x", "facet"],  # x for values, facet for time/category grouping
             optional_encodings=["color", "opacity"],
-            allowed_auxiliary=[
-                AuxiliaryElement.TARGET_LINE,
-            ],
+            allowed_auxiliary=[],  # Target line not applicable for histograms (y-axis is frequency)
         )
 
     def build(

--- a/src/chartelier/core/chart_builder/templates/p23/overlay_histogram.py
+++ b/src/chartelier/core/chart_builder/templates/p23/overlay_histogram.py
@@ -7,7 +7,6 @@ import altair as alt
 import polars as pl
 
 from chartelier.core.chart_builder.base import BaseTemplate, TemplateSpec
-from chartelier.core.enums import AuxiliaryElement
 from chartelier.core.models import MappingConfig
 
 
@@ -26,9 +25,7 @@ class OverlayHistogramTemplate(BaseTemplate):
             pattern_ids=["P23"],  # Difference + Overview - Category-wise distribution comparison
             required_encodings=["x", "color"],  # x for values, color for category grouping
             optional_encodings=["opacity"],
-            allowed_auxiliary=[
-                AuxiliaryElement.TARGET_LINE,
-            ],
+            allowed_auxiliary=[],  # Target line not applicable for histograms (y-axis is frequency)
         )
 
     def build(

--- a/tests/unit/core/chart_builder/test_histogram_template.py
+++ b/tests/unit/core/chart_builder/test_histogram_template.py
@@ -7,7 +7,6 @@ import polars as pl
 import pytest
 
 from chartelier.core.chart_builder.templates.p03.histogram import HistogramTemplate
-from chartelier.core.enums import AuxiliaryElement
 from chartelier.core.models import MappingConfig
 
 
@@ -114,17 +113,6 @@ class TestHistogramTemplate:
 
         chart_dict = chart.to_dict()
         assert "color" in chart_dict["encoding"]
-
-    def test_auxiliary_target_line_not_applicable(self, template: HistogramTemplate, sample_data: pl.DataFrame) -> None:
-        """Test that target line doesn't apply to histograms (no y-axis mapping)."""
-        mapping = MappingConfig(x="values")
-        chart = template.build(sample_data, mapping)
-
-        # Apply target line - won't add anything since histograms don't have y mapping
-        chart_with_aux = template.apply_auxiliary(chart, [AuxiliaryElement.TARGET_LINE], sample_data, mapping)
-
-        # Should return the original chart since target line requires y mapping
-        assert isinstance(chart_with_aux, alt.Chart)
 
     def test_zero_origin_enforced(self, template: HistogramTemplate, sample_data: pl.DataFrame) -> None:
         """Test that histogram Y-axis starts at zero as per Visualization Policy."""


### PR DESCRIPTION
## Summary
Remove `TARGET_LINE` auxiliary element from all histogram templates as it's not applicable to histograms.

## Problem
Histogram templates (P03, P13, P23) currently list `TARGET_LINE` as an allowed auxiliary element, but this doesn't make sense because:
- Histograms use `count()` for the y-axis (frequency), not data values
- The base implementation of `target_line` expects `mapping.y` to exist with actual data values
- Since histograms don't have `mapping.y`, the target_line is never actually applied

## Changes
- ✅ Remove `TARGET_LINE` from `allowed_auxiliary` list in:
  - `P03_histogram`
  - `P13_facet_histogram` 
  - `P23_overlay_histogram`
- ✅ Remove unused `AuxiliaryElement` imports
- ✅ Remove obsolete test case that was verifying this non-applicable behavior
- ✅ Add explanatory comments about why auxiliary list is empty

## Test Results
- All unit tests passing (7 histogram-specific tests)
- Type checking passes
- Linting passes
- All histogram-related tests pass (10 tests total)

## Impact
This is a bug fix that corrects the template specifications. No breaking changes as the target_line was never actually functional for histograms.