### PR TITLE
fix: apply custom colors to P13, P31, and P32 patterns

### DIFF
--- a/src/chartelier/core/chart_builder/colors.py
+++ b/src/chartelier/core/chart_builder/colors.py
@@ -139,8 +139,9 @@ class ColorStrategy:
                 "stroke_width": self.style.LINE_WIDTH_DEFAULT,
             },
             PatternID.P13: {  # Distribution over time (faceted)
-                "scheme": "blues",  # Use Altair's built-in scheme
-                "custom_range": self.data.BLUES_9,
+                "scheme": self._get_categorical_scheme(series_count),
+                "custom_range": list(self.data.CHARTELIER_QUAL_10),
+                "fill_opacity": self.style.BAR_FILL_OPACITY,
             },
             PatternID.P21: {  # Grouped bar
                 "scheme": self._get_categorical_scheme(series_count),


### PR DESCRIPTION
## Summary
- Fixed custom color application for patterns P13, P31, and P32 to use CHARTELIER_QUAL_10 palette
- Ensured consistent color scheme across all visualization patterns

## Changes
- **P13_facet_histogram**: Added default color from custom palette when no color mapping exists
- **P31_small_multiples**: Applied CHARTELIER_QUAL_10 palette for color encoding
- **P32_box_plot**: Added default color from custom palette when no color mapping exists  
- **colors.py**: Updated P13 pattern to use CHARTELIER_QUAL_10 instead of blues palette

## Test plan
- [x] Unit tests pass for all affected patterns (P13, P31, P32)
- [x] Visual output tests generate correct colors
- [x] Linting and type checking pass
- [x] Pre-commit hooks pass

## Visual confirmation
All three patterns now correctly display the custom Japanese traditional color palette:
- P13: Dark blue (#08192D) for histogram bars
- P31: Custom palette for multi-line series
- P32: Dark blue (#08192D) for box plots

🤖 Generated with [Claude Code](https://claude.ai/code)